### PR TITLE
Add threads flag

### DIFF
--- a/m3u8dl/core/download_process.py
+++ b/m3u8dl/core/download_process.py
@@ -66,6 +66,8 @@ class DownloadProcess:
             A flag to keep track of the whether the downloaded video should be converted
         debug: bool
             A flag to print messages to the console
+        threads: int
+            The number of threads to be used by each process
         """
         self.__session: requests.Session = session
         self.__total_links: int = total_links

--- a/m3u8dl/core/download_process.py
+++ b/m3u8dl/core/download_process.py
@@ -20,12 +20,13 @@ import os
 
 
 def download_process(links, total_links, session, http2, max_retries,
-                     convert, file_link_maps, path_prefix, debug, progress_bar_queue) -> None:
+                     convert, file_link_maps, path_prefix, debug, progress_bar_queue,
+                     threads) -> None:
     print(f"Starting Download process {current_process().name}")
     start_time = time()
     try:
         download_manager = DownloadProcess(links, total_links, session, http2,
-                                           max_retries, convert, debug)
+                                           max_retries, convert, debug, threads)
 
         start_processes(download_manager, file_link_maps, path_prefix, progress_bar_queue)
         try:
@@ -45,7 +46,8 @@ def download_process(links, total_links, session, http2, max_retries,
 class DownloadProcess:
     def __init__(self, links: List[str], total_links: int, session: requests.Session,
                  http2: bool = False, max_retries: int = 5,
-                 convert: bool = True, debug: bool = False):
+                 convert: bool = True, debug: bool = False,
+                 threads: int = 0):
         """Initialize Object of DownloadProcess.
 
         Parameters
@@ -73,7 +75,7 @@ class DownloadProcess:
         self.convert = convert
         self.__sent = 0
         self.__process_num = len(os.sched_getaffinity(os.getpid())) if platform.system() == "Linux" else 4
-        self.__thread_num = int(ceil((total_links - self.__sent) / (self.__process_num * 4)))
+        self.__thread_num = threads or int(ceil((total_links - self.__sent) / (self.__process_num * 4)))
         self.debug = debug
         self.done_retries = 0
         self.error_links = []

--- a/m3u8dl/core/m3u8dl.py
+++ b/m3u8dl/core/m3u8dl.py
@@ -42,6 +42,8 @@ def main():
     parser.add_argument("-c", "--convert", help="Convert the downloaded video to mp4 using ffmpeg", action="store_true")
     parser.add_argument("-d", "--debug", help="Print helpful messages to the terminal to "
                                               "help understanding the process flow", action="store_true")
+    parser.add_argument("-t", "--threads", type=int, help="Specify number of threads by default 4 will be "
+                                                        "initiated for each process")
 
     cli_args = parser.parse_args()
 
@@ -106,7 +108,7 @@ def main():
         progress_bar_process.start()
 
         download_process(links, len(links), sess, http2, MAX_RETRIES, cli_args.convert,
-                         file_link_maps, path_prefix, debug, queue)
+                         file_link_maps, path_prefix, debug, queue, cli_args.threads)
 
         server.join()
         video.join()


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, etc.)?**

It adds a new feature that allows users to customise how many threads are used for downloading.


**What is the current state prior to this change?**

Currently it defaults to four threads per process

**Additional clarity on why this change is necessary:**

Closes https://github.com/excalibur-kvrv/m3u8-dl/issues/36

